### PR TITLE
rpcTaskInit is not required with the libbsd networking stack

### DIFF
--- a/asyn/vxi11/osiRpc.h
+++ b/asyn/vxi11/osiRpc.h
@@ -22,7 +22,11 @@
 #ifdef __rtems__
 #include <rpc/pmap_clnt.h>
 #include <rtems.h>
+#ifdef RTEMS_LIBBSD_STACK
+#define rpcTaskInit() 0
+#else
 #define rpcTaskInit rtems_rpc_task_init
+#endif
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
Fixes build error.